### PR TITLE
add default args 'offset' at next_sequence_id method

### DIFF
--- a/lib/active_record/sharding/sequencer.rb
+++ b/lib/active_record/sharding/sequencer.rb
@@ -23,8 +23,8 @@ module ActiveRecord
           execute_sql "id"
         end
 
-        def next_sequence_id
-          execute_sql "id +1"
+        def next_sequence_id(offset = 1)
+          execute_sql "id +#{offset}"
         end
 
         def execute_sql(last_insert_id_args)

--- a/spec/active_record/sharding/sequencer_spec.rb
+++ b/spec/active_record/sharding/sequencer_spec.rb
@@ -34,5 +34,13 @@ describe ActiveRecord::Sharding::Model do
     it "next sequence id > current sequence id" do
       expect(model.current_sequence_id).to be < model.next_sequence_id
     end
+    context "when offset is selected" do
+      let(:offset) { 10 }
+      it "returns current_sequence_id with offset" do
+        next_id = model.current_sequence_id + offset
+        expect(next_id).to eq model.next_sequence_id(offset)
+        expect(next_id).to eq model.current_sequence_id
+      end
+    end
   end
 end


### PR DESCRIPTION
`next_sequence_id`メソッドにデフォルト引数の`offset`を追加しました。
これにより、sequencerに毎回アクセスせず複数のレコード挿入が可能になります。
