### PR TITLE
Output sequencer table name when initial record inserted

### DIFF
--- a/lib/active_record/sharding/database_tasks.rb
+++ b/lib/active_record/sharding/database_tasks.rb
@@ -200,6 +200,7 @@ Missing cluster_name. Find cluster_name via `rake active_record:sharding:info` t
           records_count = sequencer_records_count sequencer
 
           if records_count == 0
+            puts "Insert initial sequencer record into #{sequencer.table_name} table."
             insert_initial_record_sql = "INSERT INTO #{sequencer.table_name} VALUES (0)"
             execute sequencer.connection_name.to_s, insert_initial_record_sql
           else


### PR DESCRIPTION
Simply I added an output.
I'd like to know the tables in which the initial sequencer record was inserted, rather than existing tables.
