### PR TITLE
Support marshalling and unmarshalling

### DIFF
--- a/lib/active_record/sharding/abstract_repository.rb
+++ b/lib/active_record/sharding/abstract_repository.rb
@@ -5,20 +5,21 @@ module ActiveRecord
 
         def generate_model_for_shard(connection_name)
           base_class_name = @base_class.name
-          class_name = generate_class_name connection_name
+          class_name      = generate_class_name connection_name
 
-          model = Class.new(base_class) do
+          return @base_class.const_get(class_name) if @base_class.const_defined?(class_name)
+
+          @base_class.const_set(class_name, Class.new(base_class) do
             self.table_name = base_class.table_name
 
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                  def self.name
-                    "#{base_class_name}::#{class_name}"
-                  end
-                RUBY
-          end
+              def self.name
+                "#{base_class_name}::#{class_name}"
+              end
 
-          model.class_eval { establish_connection(connection_name) }
-          model
+              establish_connection(connection_name)
+            RUBY
+          end)
         end
 
         def generate_class_name(connection_name) # rubocop:disable Lint/UnusedMethodArgument

--- a/spec/active_record/sharding/model_spec.rb
+++ b/spec/active_record/sharding/model_spec.rb
@@ -150,4 +150,19 @@ describe ActiveRecord::Sharding::Model do
       end
     end
   end
+
+  describe "Marshaling" do
+    let(:charlie) { User.put!(name: "Charlie") }
+    describe Marshal, ".dump" do
+      it "dumps successfully." do
+        expect { Marshal.dump(charlie) }.to_not raise_error
+      end
+    end
+
+    describe Marshal, ".load" do
+      it "loads successfully" do
+        expect(Marshal.load(Marshal.dump(charlie))).to eq charlie
+      end
+    end
+  end
 end


### PR DESCRIPTION
`activerecord-sharding` do not support marshalling, unmarshalling and caching with `Rails.cache`. 

``` ruby
user = User.shard_for(1).find(1) # => #<Class:.......>
Marshal.dump(user) # => TypeError: can't dump anonymous class
Rails.cache.fetch("user_1") { User.shard_for(1).find(1) } # => #<Class:.......>
Rails.cache.read("user_1") # => nil
Rails.cache.fetch("user_1") { User.shard_for(1).find(1) } # => #<Class:.......> (w/o cache)
```

Marshal can't dump anonymous Class/Module objects, but sharding models are based on an anonymous class.

This changes behavior to return named class.

``` ruby
user = User.shard_for(1).find(1) # => #<User::ShardForUser002:.......>
Marshal.dump(user) # => return a Marshal string
Marshal.load(Marshal.dump(user)) # => #<User::ShardForUser002:.......>
Rails.cache.fetch("user_1") { User.shard_for(1).find(1) } # => #<User::ShardForUser002:.......>
Rails.cache.read("user_1") # => #<User::ShardForUser002:.......>
Rails.cache.fetch("user_1") { User.shard_for(1).find(1) } # => #<User::ShardForUser002:.......> (w/ cache)
```
