### PR TITLE
Assign next_sequence_id automatically before put/save

### DIFF
--- a/lib/active_record/sharding/facade.rb
+++ b/lib/active_record/sharding/facade.rb
@@ -8,12 +8,12 @@ module ActiveRecord
       include Model
       include Sequencer
 
-      included do |base|
-        base.before_put do |attributes|
+      included do
+        before_put do |attributes|
           attributes[:id] ||= next_sequence_id
         end
 
-        base.before_save on: :create do
+        before_save on: :create do
           self.id ||= self.class.next_sequence_id
         end
       end

--- a/lib/active_record/sharding/facade.rb
+++ b/lib/active_record/sharding/facade.rb
@@ -1,0 +1,22 @@
+require "active_support/concern"
+
+module ActiveRecord
+  module Sharding
+    module Facade
+      extend ActiveSupport::Concern
+
+      include Model
+      include Sequencer
+
+      included do |base|
+        base.before_put do |attributes|
+          attributes[:id] ||= next_sequence_id
+        end
+
+        base.before_save on: :create do
+          self.id ||= self.class.next_sequence_id
+        end
+      end
+    end
+  end
+end

--- a/lib/activerecord-sharding.rb
+++ b/lib/activerecord-sharding.rb
@@ -13,6 +13,7 @@ require "active_record/sharding/model"
 require "active_record/sharding/sequencer"
 require "active_record/sharding/sequencer_repository"
 require "active_record/sharding/sequencer_config"
+require "active_record/sharding/facade"
 
 module ActiveRecord
   module Sharding

--- a/spec/active_record/sharding/facade_spec.rb
+++ b/spec/active_record/sharding/facade_spec.rb
@@ -1,0 +1,47 @@
+describe ActiveRecord::Sharding::Facade do
+  let!(:model) do
+    Class.new(ActiveRecord::Base) do
+      def self.name
+        "User"
+      end
+
+      include ActiveRecord::Sharding::Facade
+
+      use_sharding :user, :modulo
+      define_sharding_key :id
+      use_sequencer :user
+    end
+  end
+
+  describe "including modules" do
+    it "includes ActiveRecord::Sharding::Model and ActiveRecord::Sharding::Sequencer" do
+      expect(model).to be_include ActiveRecord::Sharding::Model
+      expect(model).to be_include ActiveRecord::Sharding::Sequencer
+    end
+  end
+
+  shared_examples_for "successfully" do
+    it "inserts a record" do
+      expect(alice.persisted?).to be true
+      expect(alice.id).to eq model.current_sequence_id
+      expect(alice.name).to eq "Alice"
+      expect(alice.class.name).to match /User::ShardFor/
+    end
+  end
+
+  describe ".put!" do
+    let(:alice) { model.put!(name: "Alice") }
+
+    it_behaves_like "successfully"
+  end
+
+  describe ".new and #save" do
+    let(:alice) do
+      alice = model.shard_for(1).new(name: "Alice")
+      alice.save
+      alice
+    end
+
+    it_behaves_like "successfully"
+  end
+end

--- a/spec/active_record/sharding/facade_spec.rb
+++ b/spec/active_record/sharding/facade_spec.rb
@@ -25,7 +25,7 @@ describe ActiveRecord::Sharding::Facade do
       expect(alice.persisted?).to be true
       expect(alice.id).to eq model.current_sequence_id
       expect(alice.name).to eq "Alice"
-      expect(alice.class.name).to match /User::ShardFor/
+      expect(alice.class.name).to match(/User::ShardFor/)
     end
   end
 


### PR DESCRIPTION
When using activerecord-sharding, it is necessary to add following code snippet to our active record model classes.

```ruby
  before_put do |attributes|
    attributes[:id] ||= next_sequence_id
  end

  # this part is not written on README.md, but is needed for Model.shard_for(...).new(...).save.
  before_save on: :create do
    self.id ||= self.class.next_sequence_id
  end
```

`before_put` is from ActiveRecord::Sharding::Model, `next_sequence_id` is from ActiveRecord::Sharding::Sequencer.

Now, when I use activerecord-sharding, I always include both extensions into my models.
So, I propose to define a unified module, ActiveRecord::Sharding::Facade.